### PR TITLE
emit font files and images, and change cdn to point to npm pkg

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -113,20 +113,20 @@ const config = env => {
     fontFileLoader = {
       loader: 'file-loader',
       options: {
-        emitFile: false,
-        name: '[name].[ext]',
+        emitFile: true,
+        name: 'fonts/[name].[ext]',
         publicPath:
-          'https://cdn.jsdelivr.net/gh/HandsFree/accessangel/src/fonts/',
+          'https://cdn.jsdelivr.net/npm/@handsfree/accessangel@latest/public/dist/accessangel/fonts/',
       },
     };
 
     imageFileLoader = {
       loader: 'file-loader',
       options: {
-        emitFile: false,
-        name: '[name].[ext]',
+        emitFile: true,
+        name: 'images/[name].[ext]',
         publicPath:
-          'https://cdn.jsdelivr.net/gh/HandsFree/accessangel/src/images/',
+          'https://cdn.jsdelivr.net/npm/@handsfree/accessangel@latest/public/dist/accessangel/images/',
       },
     };
   }


### PR DESCRIPTION
Images and fonts will no longer be served from github, and instead from npm package.
