### PR TITLE
remove renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,0 @@
-{
-    "extends": [
-        "config:base",
-        "schedule:nonOfficeHours"
-    ],
-    "automerge": true,
-    "baseBranches": ["nightly"]
-}


### PR DESCRIPTION
Remove renovate in favour of manual upgrade cycle. Renovate causes bloat PRs and increased uncertainty for origin of issues when automerge is enabled. 